### PR TITLE
Add links for common next steps to the overview page

### DIFF
--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -24,4 +24,26 @@ Note that if multiple people need to manage a plugin, they will have to share th
 
 Users who already belong to an Adobe Enterprise or Team organization require either System Administrator or Developer permissions to access the Adobe Developer Console. If you are denied access to Developer Distribution when logging in with a “Company” Adobe ID, [contact your system administrator](https://helpx.adobe.com/enterprise/kb/contact-administrator.html) about getting Developer permissions assigned. More information about user management can be found in [the Adobe Admin Console guide](https://helpx.adobe.com/enterprise/using/setup-enterprise-id.html).
 
+
+<DiscoverBlock slots="heading, link, text"/>
+
+## Next Steps
+
+[Getting started](./getting_started.md)
+
+Get to know the key concepts around the developer distribution portal.
+
+<DiscoverBlock slots="link, text"/>
+
+[Get a Plugin ID](./plugin_id.md)
+
+Learn how to get a plugin ID for your plugin.
+
+<DiscoverBlock slots="link, text"/>
+
+[Submission and Review](./submission/overview.md)
+
+Learn about the submission and review process for your plugin.
+
+<br/>
 <br/>

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -46,4 +46,3 @@ Learn how to get a plugin ID for your plugin.
 Learn about the submission and review process for your plugin.
 
 <br/>
-<br/>

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -44,4 +44,4 @@ Learn how to get a plugin ID for your plugin.
 
 Learn about the submission and review process for your plugin.
 
-<br/>
+<br/><br/>

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -24,7 +24,6 @@ Note that if multiple people need to manage a plugin, they will have to share th
 
 Users who already belong to an Adobe Enterprise or Team organization require either System Administrator or Developer permissions to access the Adobe Developer Console. If you are denied access to Developer Distribution when logging in with a “Company” Adobe ID, [contact your system administrator](https://helpx.adobe.com/enterprise/kb/contact-administrator.html) about getting Developer permissions assigned. More information about user management can be found in [the Adobe Admin Console guide](https://helpx.adobe.com/enterprise/using/setup-enterprise-id.html).
 
-
 <DiscoverBlock slots="heading, link, text"/>
 
 ## Next Steps


### PR DESCRIPTION
By itself, the overview page is outside the "Next page" / "Previous page" link flow of the Gatsby theme. Instead, this links to the standard next pages at the end of the natural reading flow on the overview page.

![image](https://user-images.githubusercontent.com/25147704/218607437-be20c412-3e4b-4e65-827e-0273b9530290.png)
