### PR TITLE
Add more margin to the "next steps" on the main documentation page

### DIFF
--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -69,6 +69,8 @@ Note that if multiple people need to manage a plugin, they will have to share th
 
 Users who already belong to an Adobe Enterprise or Team organization require either System Administrator or Developer permissions to access the Adobe Developer Console. If you are denied access to Developer Distribution when logging in with a “Company” Adobe ID, [contact your system administrator](https://helpx.adobe.com/enterprise/kb/contact-administrator.html) about getting Developer permissions assigned. More information about user management can be found in [the Adobe Admin Console guide](https://helpx.adobe.com/enterprise/using/setup-enterprise-id.html).
 
+<div style="margin-top: 1em">&nbsp;</div>
+
 <DiscoverBlock slots="heading, link, text"/>
 
 ## Next Steps


### PR DESCRIPTION
Preview:

![Screenshot of the current documentation, now with an additional two lines of margin on top of the "Next steps" heading](https://user-images.githubusercontent.com/25147704/222761341-e60f455b-18cf-4fd3-b858-d59136999c2c.png)
